### PR TITLE
DAQ Automatic Tests

### DIFF
--- a/stm32f413-drivers/CMR/include/CMR/can_types.h
+++ b/stm32f413-drivers/CMR/include/CMR/can_types.h
@@ -1165,6 +1165,12 @@ typedef struct {
 // ------------------------------------------------------------------------------------------------
 // DAQ Modules
 
+typedef struct
+{
+    uint8_t test_status : 1; /**<@brief 1 to start test, 0 to stop test>**/
+    uint8_t test_id : 7; /**<@brief 7 bit long randomly generated test ID >**/
+} __attribute__((packed)) cmr_canDAQTest_t;
+
 typedef struct {
     int32_t HX711_force;     /**< @brief Force from HX711 */
     float NAU7802_force;   /**< @brief Force from NAU7802 */


### PR DESCRIPTION
DAQ Automatic Tests:
Added new daq test type in can_types (although its kinda scuffed rn) and added random test_id generation before canTX to DAQ CAN