### PR TITLE
HVC Compilation Errors GCC 14

### DIFF
--- a/HVC/Src/BMB_task.c
+++ b/HVC/Src/BMB_task.c
@@ -21,7 +21,7 @@ extern volatile int BMBErrs[BOARD_NUM-1];
 #define BALANCE_DIS false
 #define TO_IGNORE 6
 
-static const temp_to_ignore[TO_IGNORE] = {2, 41, 98, 121, 123, 132};
+static const int temp_to_ignore[TO_IGNORE] = {2, 41, 98, 121, 123, 132};
 
 
 // Use array to ignore some broken thermistor channels

--- a/HVC/Src/BMB_task.c
+++ b/HVC/Src/BMB_task.c
@@ -129,7 +129,7 @@ void vBMBSampleTask(void *pvParameters) {
 
 // Lookup functions
 uint8_t getBMBMaxTempIndex(uint8_t bmb_index) {
-	int16_t maxTemp = 0xFFFF;
+	uint16_t maxTemp = 0xFFFF;
 	uint8_t cell_index = 0;
 	for (uint8_t i = 0; i < TEMP_CHANNELS; i++) {
 		int16_t temp = BMBData[bmb_index].cellTemperatures[i];

--- a/HVC/Src/bq_interface.c
+++ b/HVC/Src/bq_interface.c
@@ -25,7 +25,11 @@ static void setBMBErr(uint8_t BMBIndex, BMB_UART_ERRORS err) {
 	BMBErrs[BMBIndex] = err;
 }
 
-void turnOn() {
+//Forward Declaration
+void byteDelay(uint8_t delay);
+void txToRxDelay(uint8_t delay);
+
+bool turnOn() {
 
 	HAL_Delay(100);
 	HAL_GPIO_WritePin(
@@ -395,7 +399,7 @@ void BMBInit() {
 	HAL_Delay(100);
 
 	//No idea lol
-	txToRxDelay();
+	// txToRxDelay();
 	HAL_Delay(100);
 	byteDelay(0x3F);
 	HAL_Delay(100);

--- a/HVC/Src/can.c
+++ b/HVC/Src/can.c
@@ -42,11 +42,6 @@ cmr_canRXMeta_t canRXMeta[] = {
         .timeoutWarn_ms = 25
     },
     [CANRX_EMD_MEASURE] = {
-        .canID = CMR_CANID_EMD_MEASUREMENT,
-        .timeoutError_ms = 100,
-        .timeoutWarn_ms = 25
-    },
-    [CANRX_EMD_MEASURE] = {   
         .canID = CMR_CANID_EMD_MEASUREMENT_RETX,
         .timeoutError_ms = 50,
         .timeoutWarn_ms = 25
@@ -100,7 +95,7 @@ static void canTX1Hz(void *pvParameters) {
     TickType_t lastWakeTime = xTaskGetTickCount();
     while (1) {
 
-        // BMB Temperature Status 
+        // BMB Temperature Status
         for (uint8_t bmb_index = 0; bmb_index < BOARD_NUM - 1; bmb_index++) {
             sendBMSBMBStatusTemp(bmb_index);
         }
@@ -133,10 +128,10 @@ static void canTX10Hz(void *pvParameters) {
 
     TickType_t lastWakeTime = xTaskGetTickCount();
     while (1) {
-        // BRUSA Charger decided by state machine 
+        // BRUSA Charger decided by state machine
         // sendBRUSAChargerControl();
 
-        // BMB Voltage Status 
+        // BMB Voltage Status
         for (uint8_t bmb_index = 0; bmb_index < BOARD_NUM-1; bmb_index++) {
             sendBMSBMBStatusVoltage(bmb_index);
         }
@@ -422,7 +417,7 @@ static void sendBMSMinMaxCellVoltage(void) {
 
     uint8_t minCellVoltageBMBNum = 0;
 	uint8_t maxCellVoltageBMBNum = 0;
-	
+
 	uint8_t minCellVoltageIndex = 0;
 	uint8_t maxCellVoltageIndex = 0;
 
@@ -463,7 +458,7 @@ static void sendBMSMinMaxCellTemp(void) {
 
     uint8_t minCellTempBMBNum;
 	uint8_t maxCellTempBMBNum;
-	
+
 	uint8_t minCellTempIndex;
 	uint8_t maxCellTempIndex;
 

--- a/HVC/Src/state_task.c
+++ b/HVC/Src/state_task.c
@@ -24,12 +24,12 @@ cmr_canHVCState_t getState() {
  */
 
 static cmr_canHVCState_t getNextState(cmr_canHVCError_t currentError){
-    
+
     //Default to unknown state if no paths are satisfied.
     cmr_canHVCState_t nextState = CMR_CAN_HVC_STATE_UNKNOWN;
     static TickType_t lastPrechargeTime = 0;// = xTaskGetTickCount();
 
-    
+
     // initialize min/max cell voltage variables for next state logic
     uint16_t packMinCellVoltage;
     uint16_t packMaxCellVoltage;
@@ -93,7 +93,7 @@ static cmr_canHVCState_t getNextState(cmr_canHVCError_t currentError){
             if (HVCCommand->modeRequest != CMR_CAN_HVC_MODE_RUN) {
                 // T8: Mode requested is not RUN
                 nextState = CMR_CAN_HVC_STATE_DISCHARGE;
-            } else {                
+            } else {
                 nextState = CMR_CAN_HVC_STATE_DRIVE;
             }
             break;
@@ -172,8 +172,7 @@ static cmr_canHVCState_t getNextState(cmr_canHVCError_t currentError){
             break;
         }
         case CMR_CAN_HVC_STATE_CLEAR_ERROR: // S11
-            if ((HVCCommand->modeRequest == CMR_CAN_HVC_MODE_IDLE) &&
-                (true || getHVmillivolts()) < 5000) {
+            if ((HVCCommand->modeRequest == CMR_CAN_HVC_MODE_IDLE) || getHVmillivolts() < 5000) {
                 //T4: GLV requesting idle and rails discharged
                 nextState = CMR_CAN_HVC_STATE_STANDBY;
             } else {
@@ -185,9 +184,9 @@ static cmr_canHVCState_t getNextState(cmr_canHVCError_t currentError){
             nextState = CMR_CAN_HVC_STATE_UNKNOWN;
             break;
     }
-    
-    // Return the result of next state logic            
-    return nextState;    
+
+    // Return the result of next state logic
+    return nextState;
 }
 
 static cmr_canHVCState_t setStateOutput(){
@@ -293,7 +292,7 @@ static cmr_canHVCState_t setStateOutput(){
             clearHardwareFault(false);
             break;
     }
-    
+
     return currentState;
 }
 
@@ -332,7 +331,7 @@ void vSetStateTask(void *pvParameters) {
         // HVCHeartbeat->state = currentState;
         // HVCHeartbeat->contactorStatus = getRelayStatus();
         //taskEXIT_CRITICAL();
-        
+
 
         currentError = checkErrors(currentState);
         nextState = getNextState(currentError);

--- a/HVC/Src/uart.c
+++ b/HVC/Src/uart.c
@@ -157,7 +157,7 @@ cmr_uart_result_t uart_sendCommand(const uart_command_t *command) {
 	uint8_t message[128] = {0};
 	uint8_t currByte = 0;
 
-	uint8_t initByte = ((command->readWrite) << 4) | ((0x07 & (command->dataLen)-1));
+	uint8_t initByte = ((command->readWrite) << 4) | ((0x07 & (command->dataLen-1)));
 	message[currByte] = initByte;
 	currByte++;
 


### PR DESCRIPTION
GCC 14 throws errors not found in older versions of the compiler. Needed for static analysis